### PR TITLE
Fix SOAP controller auth and error handling

### DIFF
--- a/src/Http/Controllers/SoapController.php
+++ b/src/Http/Controllers/SoapController.php
@@ -91,7 +91,7 @@ class SoapController extends Controller
             $response = new ArrayOfString(['', 'nvu']);
 
             if (
-                $parameters->getStrUserName() == config('qbwc.user') ||
+                $parameters->getStrUserName() == config('qbwc.user') &&
                 $parameters->getStrPassword() == config('qbwc.password')
             ) {
                 $this->soapService->generateTicket();
@@ -187,7 +187,7 @@ class SoapController extends Controller
 
         try {
             $response = "Ticket: {$parameters->getTicket()} | ";
-            $response .= "Hresult: {$parameters->hresult()} | ";
+            $response .= "Hresult: {$parameters->getHresult()} | ";
             $response .= "Message: {$parameters->getMessage()}";
 
             $this->queueService->markQueueFailed();


### PR DESCRIPTION
## Summary
- enforce both username and password match in `authenticate`
- call `getHresult()` instead of missing `hresult()` method

## Testing
- `php -l src/Http/Controllers/SoapController.php` *(fails: php not installed)*