### PR TITLE
Fix PSR-4 path in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Ensure that your `composer.json` includes the necessary autoload settings:
 ```json
 "autoload": {
     "psr-4": {
-        "AaronGRTech\\QbwcLaravel\\": "./src/AaronGRTech/QbwcLaravel"
+        "AaronGRTech\\QbwcLaravel\\": "./src"
     }
 },
 "extra": {


### PR DESCRIPTION
## Summary
- update the example `composer.json` to autoload from `./src`

## Testing
- `composer validate --no-check-all --strict` *(fails: `composer` not found)*